### PR TITLE
Force regex encoding to ASCII-8BIT to fix Encoding::CompatibilityError.

### DIFF
--- a/lib/live_ast/reader.rb
+++ b/lib/live_ast/reader.rb
@@ -3,8 +3,8 @@
 
 module LiveAST
   module Reader
-    UTF8_BOM = /\A\xef\xbb\xbf/.freeze
-    MAGIC_COMMENT = /\A(?:#!.*?\n)?\s*\#.*(?:en)?coding\s*[:=]\s*([^\s;]+)/.freeze
+    UTF8_BOM = /\A\xef\xbb\xbf/n.freeze
+    MAGIC_COMMENT = /\A(?:#!.*?\n)?\s*\#.*(?:en)?coding\s*[:=]\s*([^\s;]+)/n.freeze
 
     def self.read(file)
       contents = File.read(file, encoding: "BINARY")


### PR DESCRIPTION
We were seeing the following error:

    Encoding::CompatibilityError: incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)

When using the bom regex [here](https://github.com/mvz/live_ast/blob/master/lib/live_ast/reader.rb#L12).

(We only started getting it recently though, or, only in some files (but it is consistent where we do see it).)

Forcing these regexes to have the same encoding as the File.read uses appears to fix the issue (for us).

(We don't have a lot of BOM files (afaik), so this change may not be as well tested as would be ideal :-s (The test suite did pass though.))