### PR TITLE
add a replace_caller, similar to replace_raise

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -224,6 +224,20 @@ code. An exception from within a native method will likely still
 contain the token in its backtrace (e.g., in MRI the exception raised
 by <code>1/0</code> comes from C).
 
+Similarly to replace_raise, there is a replace_caller for libraries that
+use the output of Kernel.caller directly to identify files.  This has the 
+same caveats as replace_raise.
+  
+  require 'live_ast'
+
+  f = ast_eval %{ lambda { caller.first } }, binding
+  f.call
+  => "(irb)|ast@o:7:in `irb_binding'"
+
+  require 'live_ast/replace_caller'
+  f.call
+  => "(irb):7:in `block in irb_binding'"
+
 == Replacing the Parser
 
 Despite its name, LiveAST knows nothing about ASTs. It merely reports

--- a/lib/live_ast/replace_caller.rb
+++ b/lib/live_ast/replace_caller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "live_ast/base"
+
+module Kernel
+  private
+
+  alias live_ast_original_caller caller
+  def caller(*args)
+    c = live_ast_original_caller(*args)
+    d = []
+    c.each { |s| d << s.gsub(/\|ast@.*:(\d)/,':\1') }
+    d
+  end
+end


### PR DESCRIPTION
This will replace the output of Kernel.caller when it can - this turns out to be necessary when used with some libraries, such as chef (which is our particular use case), which parse the output of caller in order to introspect into their own files.