### PR TITLE
Run RuboCop in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,3 +30,17 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake
+
+  rubocop:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - name: Run RuboCop
+      run: bundle exec rubocop -P

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,9 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, head]
-
-    continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
+        ruby: [2.4, 2.5, 2.6, 2.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -31,8 +31,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "binding_of_caller", "~> 0.8.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rdoc"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rdoc", "~> 6.2"
+  spec.add_development_dependency "rubocop", "~> 1.0.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.8.1"
 
   spec.rdoc_options = ["--main", "README.rdoc",
                        "--title", "LiveAST: Live Abstract Syntax Trees",


### PR DESCRIPTION
- Add rubocop gems as development dependencies
- Run RuboCop as a GitHub action
- Do not run CI build with ruby-head