### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7, "3.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.rdoc
+++ b/CHANGES.rdoc
@@ -1,5 +1,8 @@
-
 = live_ast Changes
+
+== Unreleased
+
+* use bindings gem instead of binding_of_caller
 
 == Version 1.3.2
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -129,8 +129,8 @@ semantics as +eval+ except that the binding argument is required.
 == Full Integration
 
 In order for LiveAST to be transparent to the user, +eval+ must be
-replaced. This is accomplished with the help of the +binding_of_caller+ gem
-(https://github.com/banister/binding_of_caller).
+replaced. This is accomplished with the help of the +bindings+ gem
+(https://github.com/shreeve/bindings).
 
 To replace +eval+,
 
@@ -149,7 +149,7 @@ below for details).
   # => s(:iter, s(:call, nil, :lambda), 0, s(:str, "dynamic1"))
 
 Since LiveAST itself is pure ruby, any platforms supported by
-+binding_of_caller+ should work with <code>live_ast/full</code>.
++bindings+ should work with <code>live_ast/full</code>.
 
 == Limitations
 

--- a/lib/live_ast/replace_eval.rb
+++ b/lib/live_ast/replace_eval.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "live_ast/base"
-require "binding_of_caller"
+require "bindings"
 
 module LiveAST
   module ReplaceEval
@@ -57,7 +57,7 @@ module Kernel
     LiveAST::Common.check_arity(args, 1..4)
     LiveAST.eval(
       args[0],
-      args[1] || binding.of_caller(1),
+      args[1] || Binding.of_caller(1),
       *LiveAST::Common.location_for_eval(*args[1..3]))
   end
 end
@@ -82,7 +82,7 @@ class BasicObject
       ::LiveAST::ReplaceEval
         .module_or_instance_eval(:instance,
                                  self,
-                                 ::Kernel.binding.of_caller(1),
+                                 ::Binding.of_caller(1),
                                  args)
     end
   end
@@ -97,7 +97,7 @@ class Module
       live_ast_original_module_eval(*args, &block)
     else
       LiveAST::ReplaceEval
-        .module_or_instance_eval(:module, self, binding.of_caller(1), args)
+        .module_or_instance_eval(:module, self, Binding.of_caller(1), args)
     end
   end
 

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ruby2ruby", "~> 2.4.0"
   spec.add_runtime_dependency "ruby_parser", "~> 3.14"
 
-  spec.add_development_dependency "binding_of_caller", "~> 0.8.0"
+  spec.add_development_dependency "bindings", "~> 1.0.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rdoc", "~> 6.2"

--- a/test/main.rb
+++ b/test/main.rb
@@ -117,7 +117,7 @@ class ReplaceEvalTest < BaseTest
            require "live_ast/full"
            true
          rescue LoadError
-           raise "need: gem install binding_of_caller" if RUBY_ENGINE == "ruby"
+           raise "need: gem install bindings" if RUBY_ENGINE == "ruby"
 
            false
          end


### PR DESCRIPTION
- Run tests on Ruby 3.0 in CI
- Replace `binding_of_caller` gem with `bindings`, since `binding_of_caller` does not work with Ruby 3.0. See https://github.com/banister/binding_of_caller/issues/77