### PR TITLE
Update support information and testing

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1"]
+        ruby: [2.6, 2.7, "3.0", "3.1", "jruby-9.3"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Update README with current minimum Ruby version
- Test with JRuby 9.3 which is compatible with Ruby 2.6
