### PR TITLE
Raise ASTNotFoundError for code defined in the prelude

### DIFF
--- a/lib/live_ast/linker.rb
+++ b/lib/live_ast/linker.rb
@@ -73,6 +73,7 @@ module LiveAST
       def find_ast(*location)
         raise ASTNotFoundError unless location.size == 2
         raise RawEvalError if location.first == "(eval)"
+        raise ASTNotFoundError if location.first == "<internal:prelude>"
 
         ast = fetch_from_cache(*location)
         raise MultipleDefinitionsOnSameLineError if ast == :multiple

--- a/test/main.rb
+++ b/test/main.rb
@@ -25,17 +25,6 @@ class JLMiniTest < MiniTest::Test
     end
   end
 
-  def delim(char)
-    "\n#{char * 72}\n"
-  end
-
-  def mu_pp(obj)
-    +"" <<
-      delim("_") <<
-      obj.pretty_inspect.chomp <<
-      delim("=")
-  end
-
   def unfixable
     yield
     raise "claimed to be unfixable, but assertion succeeded"

--- a/test/main.rb
+++ b/test/main.rb
@@ -3,7 +3,6 @@
 $LOAD_PATH.unshift File.expand_path("../lib", File.dirname(__FILE__))
 
 # require first for stdlib_test
-require "pp"
 require "find"
 require "fileutils"
 

--- a/test/stdlib_test.rb
+++ b/test/stdlib_test.rb
@@ -5,7 +5,11 @@ require_relative "main"
 class StdlibTest < RegularTest
   if stdlib_has_source?
     def test_pp
-      assert_not_nil method(:pp).to_ast
+      pp_method = method(:pp)
+      assert_equal "<internal:prelude>", pp_method.source_location.first
+      assert_raises LiveAST::ASTNotFoundError do
+        pp_method.to_ast
+      end
     end
 
     def test_find


### PR DESCRIPTION
Ruby defines a few methods in `prelude.rb`, which means these are preloaded and have no corresponding source file in the Ruby installation.

One of these methods is `Kernel.pp`, defined in the prelude since Ruby version 2.5.0. By not requiring 'pp', this definition is exposed, and `live_ast`'s behavior in this case can be defined and tested.

Without special casing the '<internal:prelude>' location, fetching the AST would raise `Errno::ENOENT` instead.

See https://bugs.ruby-lang.org/issues/14123.
