### PR TITLE
Remove rdoc task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require "rake/clean"
 require "rake/manifest/task"
 require "bundler/gem_tasks"
 require "rake/testtask"
-require "rdoc/task"
 
 namespace :test do
   desc "run tests"
@@ -51,13 +50,6 @@ namespace :test do
   end
 
   task all: [:main, :base, :ast_load, :to_ast, :to_ruby, :full]
-end
-
-RDoc::Task.new(:rdoc) do |t|
-  t.main = "README.rdoc"
-  t.title = "LiveAST: Live Abstract Syntax Trees"
-  t.options += ["--visibility", "private"]
-  t.rdoc_files.include("README.rdoc", "CHANGES.rdoc", "lib")
 end
 
 Rake::Manifest::Task.new do |t|

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rdoc", "~> 6.2"
   spec.add_development_dependency "rubocop", "~> 1.25"
   spec.add_development_dependency "rubocop-minitest", "~> 0.24.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"


### PR DESCRIPTION
This task was not used in practice. Prefer just running yardoc instead.

This also avoids rdoc's psych dependency, thus reducing installation headaches in CI.
