### PR TITLE
Avoid using RuboCop 1.40.0, which has a bug in Style/IfUnlessModifier

### DIFF
--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.25", "!= 1.40.0"
   spec.add_development_dependency "rubocop-minitest", "~> 0.24.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"


### PR DESCRIPTION
Running rubocop 1.40.0 will result in failure even when offenses are fixed. Skip that version in favor of an upcoming bugfix.
