### PR TITLE
Update range of supported Rubies to 2.7-3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
 
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.2"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: "2.7"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - 'devel/levitate.rb'
     - 'devel/levitate_config.rb'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:

--- a/README.rdoc
+++ b/README.rdoc
@@ -80,7 +80,7 @@ sexps used by tools such as <code>ruby2ruby</code>.
 
 LiveAST is thread-safe.
 
-Ruby 2.6.0 or higher is required.
+Ruby 2.7.0 or higher is required.
 
 == Links
 

--- a/lib/live_ast/common.rb
+++ b/lib/live_ast/common.rb
@@ -7,7 +7,7 @@ module LiveAST
     def arg_to_str(arg)
       arg.to_str
     rescue NameError
-      thing = arg.nil? ? nil : arg.class
+      thing = arg&.class
 
       message = "no implicit conversion of #{thing.inspect} into String"
       raise TypeError, message
@@ -16,7 +16,7 @@ module LiveAST
     def arg_to_str2(arg)
       arg.to_str
     rescue NameError
-      thing = arg.nil? ? nil : arg.class
+      thing = arg&.class
 
       message = "wrong argument type #{thing.inspect} (expected String)"
       raise TypeError, message

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/mvz/live_ast"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/live_ast"

--- a/test/covert_define_method_test.rb
+++ b/test/covert_define_method_test.rb
@@ -5,8 +5,8 @@ require_relative "main"
 class CovertDefineMethodTest < RegularTest
   DEFINE = lambda do
     class A
-      def A.my_def(*args, &block)
-        define_method(*args, &block)
+      def A.my_def(...)
+        define_method(...)
       end
 
       my_def :h do |x, y|


### PR DESCRIPTION
- Autocorrect Style/SafeNavigation offenses
- Drop support for Ruby 2.6
- Support Ruby 3.2
- Update version info in README
