### PR TITLE
Use correct Minitest namespace to access minitest classes

### DIFF
--- a/devel/levitate.rb
+++ b/devel/levitate.rb
@@ -154,7 +154,7 @@ class Levitate
 
     def doc_to_test(file, *sections, &block)
       levitate = self
-      klass = Class.new MiniTest::Test do
+      klass = Class.new Minitest::Test do
         sections.each { |section|
           define_method "test_#{file}_#{section}" do
             if block

--- a/test/eval_test.rb
+++ b/test/eval_test.rb
@@ -268,7 +268,7 @@ class EvalTest < RegularTest
 
   # from rubyspec
   def test_to_str_on_file
-    file = MiniTest::Mock.new
+    file = Minitest::Mock.new
     file.expect(:to_str, "zebra.rb")
     ast_eval "33 + 44", binding, file
     file.verify

--- a/test/full/replace_eval_test.rb
+++ b/test/full/replace_eval_test.rb
@@ -346,7 +346,7 @@ class FullReplaceEvalTest < ReplaceEvalTest
   end
 
   def test_module_eval_to_str
-    file = MiniTest::Mock.new
+    file = Minitest::Mock.new
     file.expect(:to_str, "zebra.rb")
     Class.new.module_eval("33 + 44", file)
     file.verify

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ $VERBOSE = true
 
 require "live_ast/base"
 
-class JLMiniTest < MiniTest::Test
+class JLMiniTest < Minitest::Test
   def self.test_methods
     default = super
     onlies = default.grep(/__only\Z/)
@@ -28,13 +28,13 @@ class JLMiniTest < MiniTest::Test
   def unfixable
     yield
     raise "claimed to be unfixable, but assertion succeeded"
-  rescue MiniTest::Assertion
+  rescue Minitest::Assertion
   end
 
   def assert_nothing_raised
     yield
   rescue StandardError => e
-    raise MiniTest::Assertion,
+    raise Minitest::Assertion,
           exception_details(e, "Expected nothing raised, but got:")
   end
 


### PR DESCRIPTION
Minitest stopped loading the minitest compatibility layer by default in version 5.19. Switch to the new namespace wherever the MiniTest namespace was used.
