### PR TITLE
Update rubocop-performance and fix new offenses

### DIFF
--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.51"
   spec.add_development_dependency "rubocop-minitest", "~> 0.33.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.20"
   spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
 end

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -22,21 +22,21 @@ class AllEncodingTest < RegularTest
   }.freeze
 
   ENC_TESTS.each_pair do |abbr, name|
-    define_method "test_#{abbr}" do
+    define_method :"test_#{abbr}" do
       require_relative "encoding_test/#{abbr}"
       self.class.class_eval { include EncodingTest }
 
-      str = send("#{abbr}_string")
+      str = send(:"#{abbr}_string")
 
       assert_equal name, str.encoding.to_s
 
-      ast = EncodingTest.instance_method("#{abbr}_string").to_ast
+      ast = EncodingTest.instance_method(:"#{abbr}_string").to_ast
 
       assert_equal "UTF-8", no_arg_def_return(ast).encoding.to_s
 
       LiveAST.load "./test/encoding_test/#{abbr}.rb"
 
-      ast = EncodingTest.instance_method("#{abbr}_string").to_ast
+      ast = EncodingTest.instance_method(:"#{abbr}_string").to_ast
 
       assert_equal "UTF-8", no_arg_def_return(ast).encoding.to_s
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,7 @@ class JLMiniTest < Minitest::Test
     empty equal in_delta in_epsilon includes instance_of
     kind_of match nil operator respond_to same
   ).each { |name|
-    alias_method "assert_not_#{name}", "refute_#{name}"
+    alias_method :"assert_not_#{name}", "refute_#{name}"
   }
 end
 


### PR DESCRIPTION
- Update rubocop-performance dependency
- Autocorrect Performance/StringIdentifierArgument
