### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - 'devel/levitate.rb'
     - 'devel/levitate_config.rb'
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/lib/live_ast/reader.rb
+++ b/lib/live_ast/reader.rb
@@ -3,8 +3,8 @@
 
 module LiveAST
   module Reader
-    UTF8_BOM = /\A\xef\xbb\xbf/.freeze
-    MAGIC_COMMENT = /\A(?:#!.*?\n)?\s*\#.*(?:en)?coding\s*[:=]\s*([^\s;]+)/.freeze
+    UTF8_BOM = /\A\xef\xbb\xbf/
+    MAGIC_COMMENT = /\A(?:#!.*?\n)?\s*\#.*(?:en)?coding\s*[:=]\s*([^\s;]+)/
 
     def self.read(file)
       contents = File.read(file, encoding: "BINARY")

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/mvz/live_ast"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/live_ast"


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Stop building on Ruby 2.7 in CI
- Autocorrect Style/RedundantFreeze
