### PR TITLE
Fix source location for eval with binding and no location

### DIFF
--- a/lib/live_ast/common.rb
+++ b/lib/live_ast/common.rb
@@ -43,15 +43,12 @@ module LiveAST
       raise TypeError, message
     end
 
-    def location_for_eval(bind = nil, filename = nil, lineno = nil)
-      if bind
-        if filename
-          lineno ||= 1
-          [filename, lineno]
-        else
-          bind.source_location
-        end
+    def location_for_eval(bind, filename = nil, lineno = nil)
+      if filename
+        lineno ||= 1
+        [filename, lineno]
       else
+        bind.source_location
         ["(eval)", 1]
       end
     end

--- a/lib/live_ast/replace_eval.rb
+++ b/lib/live_ast/replace_eval.rb
@@ -57,7 +57,7 @@ module Kernel
     LiveAST.eval(
       string,
       binding || Binding.of_caller(1),
-      *LiveAST::Common.location_for_eval(binding, filename, lineno))
+      filename, lineno)
   end
 end
 

--- a/test/backtrace_test.rb
+++ b/test/backtrace_test.rb
@@ -34,7 +34,7 @@ class BacktraceTest < RegularTest
   def test_raise_no_overrides
     3.times do
       orig = exception_backtrace do
-        eval <<~RUBY, binding, __FILE__, (__LINE__ + 9)
+        eval <<~RUBY, binding
 
 
           raise
@@ -52,9 +52,6 @@ class BacktraceTest < RegularTest
       end
 
       assert_equal orig.first, live.first
-      here = Regexp.quote __FILE__
-
-      assert_match(/#{here}/, live.first)
     end
   end
 

--- a/test/full/replace_eval_test.rb
+++ b/test/full/replace_eval_test.rb
@@ -403,7 +403,7 @@ class FullReplaceEvalTest < ReplaceEvalTest
     assert_equal 33, Class.new.instance_eval("args")
   end
 
-  def test_location_without_binding
+  def test_eval_location_without_binding
     expected = ["(eval)", 2]
 
     assert_equal expected, live_ast_original_eval("\n[__FILE__, __LINE__]")
@@ -413,6 +413,21 @@ class FullReplaceEvalTest < ReplaceEvalTest
     end
 
     file, line = eval("\n[__FILE__, __LINE__]")
+    file = LiveAST.strip_token file
+
+    assert_equal expected, [file, line]
+  end
+
+  def test_eval_location_with_binding
+    expected = ["(eval)", 2]
+
+    assert_equal expected, live_ast_original_eval("\n[__FILE__, __LINE__]", binding)
+
+    unfixable do
+      assert_equal expected, eval("\n[__FILE__, __LINE__]", binding)
+    end
+
+    file, line = eval("\n[__FILE__, __LINE__]", binding)
     file = LiveAST.strip_token file
 
     assert_equal expected, [file, line]


### PR DESCRIPTION
When using binding but no location, the original behavior is to set the source location to "(eval)". This change makes the eval replacement behave the same way.
