### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
                        "--visibility", "private"]
   spec.extra_rdoc_files = ["README.rdoc", "CHANGES.rdoc"]
 
-  spec.add_runtime_dependency "ruby2ruby", ">= 2.4", "< 2.6"
-  spec.add_runtime_dependency "ruby_parser", "~> 3.14"
+  spec.add_dependency "ruby2ruby", ">= 2.4", "< 2.6"
+  spec.add_dependency "ruby_parser", "~> 3.14"
 
   spec.add_development_dependency "bindings", "~> 1.0.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
