### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - 'devel/levitate.rb'
     - 'devel/levitate_config.rb'
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
     generated code.
   DESC
   spec.homepage = "https://github.com/mvz/live_ast"
+
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/live_ast"
@@ -38,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-focus", "~> 1.4"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.51"
+  spec.add_development_dependency "rubocop", "~> 1.70"
   spec.add_development_dependency "rubocop-minitest", "~> 0.36.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.20"

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -49,9 +49,18 @@ class AllEncodingTest < RegularTest
     live = assert_raises ArgumentError do
       LiveAST.load "./test/encoding_test/bad.rb"
     end
-    re = /\Aunknown encoding name:\s*feynman-diagram\Z/
 
-    assert_match re, orig.message
-    assert_match re, live.message
+    assert_equal orig.class, live.class
+
+    if RUBY_VERSION >= "3.4."
+      # Ruby 3.4 changed how bad magic encoding comments are reported, and the
+      # message is difficult to replicate. Use the old message format for now.
+      assert_match(
+        /unknown or invalid encoding in the magic comment\n.*# encoding: feynman-diagram\n/,
+        orig.message)
+      assert_equal "unknown encoding name: feynman-diagram", live.message
+    else
+      assert_equal orig.message, live.message
+    end
   end
 end


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
