### PR TITLE
Make load error message match original exactly

### DIFF
--- a/lib/live_ast/reader.rb
+++ b/lib/live_ast/reader.rb
@@ -13,8 +13,14 @@ module LiveAST
 
       # magic comment overrides BOM
       encoding = contents[MAGIC_COMMENT, 1] || utf8 || "US-ASCII"
+      encoding = strip_special encoding
+      begin
+        Encoding.find encoding
+      rescue ArgumentError
+        raise ArgumentError, "unknown encoding name: #{encoding}"
+      end
 
-      contents.force_encoding(strip_special(encoding))
+      contents.force_encoding encoding
     end
 
     def self.strip_special(encoding)

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -49,8 +49,7 @@ class AllEncodingTest < RegularTest
     live = assert_raises ArgumentError do
       LiveAST.load "./test/encoding_test/bad.rb"
     end
-    # inconsistent punctuation from Ruby
-    re = /\Aunknown encoding name\s*[-:]\s*feynman-diagram\Z/
+    re = /\Aunknown encoding name:\s*feynman-diagram\Z/
 
     assert_match re, orig.message
     assert_match re, live.message


### PR DESCRIPTION
The encoding error from `Kernel.load` is different from that produced by `#force_encoding`. Matching the message exactly will make it easier to adapt to changes in `Kernel.load`'s message for Ruby 3.4.
