### PR TITLE
Replace RubyParser with Prism's RubyParser-compatible translation layer

### DIFF
--- a/lib/live_ast/ruby_parser.rb
+++ b/lib/live_ast/ruby_parser.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "ruby_parser"
+require "prism"
 require "live_ast/base"
 
 module LiveAST
@@ -13,7 +13,7 @@ module LiveAST
     #
     def parse(source)
       @defs = {}
-      process ::RubyParser.new.parse(source)
+      process ::Prism::Translation::RubyParser.new.parse(source)
       @defs
     end
 

--- a/lib/live_ast/ruby_parser/test.rb
+++ b/lib/live_ast/ruby_parser/test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "ruby2ruby"
 #
 # Used by the LiveAST test suite.
 #

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
                        "--visibility", "private"]
   spec.extra_rdoc_files = ["README.rdoc", "CHANGES.rdoc"]
 
-  spec.add_dependency "ruby2ruby", ">= 2.4", "< 2.7"
+  spec.add_dependency "ruby2ruby", "~> 2.6"
   spec.add_dependency "ruby_parser", "~> 3.14"
 
   spec.add_development_dependency "bindings", "~> 1.0.0"

--- a/live_ast.gemspec
+++ b/live_ast.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["README.rdoc", "CHANGES.rdoc"]
 
   spec.add_dependency "ruby2ruby", "~> 2.6"
-  spec.add_dependency "ruby_parser", "~> 3.14"
 
   spec.add_development_dependency "bindings", "~> 1.0.0"
   spec.add_development_dependency "minitest", "~> 6.0"

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -32,13 +32,13 @@ class AllEncodingTest < RegularTest
 
       ast = EncodingTest.instance_method(:"#{abbr}_string").to_ast
 
-      assert_equal "UTF-8", no_arg_def_return(ast).encoding.to_s
+      assert_equal name, no_arg_def_return(ast).encoding.to_s
 
       LiveAST.load "./test/encoding_test/#{abbr}.rb"
 
       ast = EncodingTest.instance_method(:"#{abbr}_string").to_ast
 
-      assert_equal "UTF-8", no_arg_def_return(ast).encoding.to_s
+      assert_equal name, no_arg_def_return(ast).encoding.to_s
     end
   end
 


### PR DESCRIPTION
- **Bump ruby2ruby version so it no longer requires ruby_parser**
- **Replace RubyParser with Prism's RubyParser compatibility layer**
- **Update encoding test expectations**
