### PR TITLE
Change default script encoding to UTF-8.

### DIFF
--- a/lib/live_ast/reader.rb
+++ b/lib/live_ast/reader.rb
@@ -12,7 +12,7 @@ module LiveAST
       utf8 = contents.sub!(UTF8_BOM, "") ? "UTF-8" : nil
 
       # magic comment overrides BOM
-      encoding = contents[MAGIC_COMMENT, 1] || utf8 || "US-ASCII"
+      encoding = contents[MAGIC_COMMENT, 1] || utf8 || "UTF-8"
       encoding = strip_special encoding
       begin
         Encoding.find encoding


### PR DESCRIPTION
Thanks for live_ast :-) :pray: 

We ran into an issue relating to script encoding, and found it's an inconsistency between Ruby and live_ast.

We ran into a `syntax error found (SyntaxError)` due to `invalid multibyte character 0xE2` when using live_ast.  We did some manual verification using `live_ast_original_load` to compare the behaviour, and found that it was live_ast specific.

The default script encoding has been utf-8 since Ruby 2.0.0 - so just moving this code over to default to `utf-8` like Ruby does :-)

Thanks again :-)